### PR TITLE
Forced use of uri 1.0.3, i

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ gem "jekyll-github-metadata"
 # Security patch
 # REF: https://security.snyk.io/vuln/SNYK-RUBY-WEBRICK-8068535
 gem 'webrick', '1.9.1'
+
+# Security patch
+# REF: https://github.com/advisories/GHSA-22h5-pq3x-2gf2
+gem 'uri', '1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.2)
+    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS
@@ -282,6 +282,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll-github-metadata
+  uri (= 1.0.3)
   webrick (= 1.9.1)
 
 BUNDLED WITH


### PR DESCRIPTION
REF:
- https://github.com/advisories/GHSA-22h5-pq3x-2gf2
- https://www.cve.org/CVERecord?id=CVE-2025-27221
